### PR TITLE
feat: 추천 피드 리스트 filter 기능 구현

### DIFF
--- a/src/components/common/Battles.tsx
+++ b/src/components/common/Battles.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+
+function Battles() {
+  const router = useRouter();
+
+  const changeBattleStatus = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (e.currentTarget.value === '대결 가능') router.push(`/post?possible=true`);
+    else router.push(`/post?possible=false`);
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          width: '200px',
+          height: '100px',
+          display: 'flex',
+          justifyContent: 'space-between',
+        }}
+      >
+        <button onClick={changeBattleStatus} value='대결 가능'>
+          대결 가능
+        </button>
+        <button onClick={changeBattleStatus} value='대결 불가능'>
+          대결 불가능
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default Battles;

--- a/src/components/common/Battles.tsx
+++ b/src/components/common/Battles.tsx
@@ -4,8 +4,8 @@ function Battles() {
   const router = useRouter();
 
   const changeBattleStatus = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (e.currentTarget.value === '대결 가능') router.push(`/post?possible=true`);
-    else router.push(`/post?possible=false`);
+    if (e.currentTarget.value === '대결 가능') router.push(`/post?battle=true`);
+    else router.push(`/post?battle=false`);
   };
 
   return (

--- a/src/components/post/api.ts
+++ b/src/components/post/api.ts
@@ -25,7 +25,7 @@ const DUMMY_DATA = {
           genre: '힙합 / 랩',
         },
         likeCount: 10,
-        isBattlePossible: true,
+        isBattlePossible: false,
         nickname: 'Hype',
       },
       {
@@ -49,7 +49,7 @@ const DUMMY_DATA = {
           genre: '락 / 메탈',
         },
         likeCount: 10,
-        isBattlePossible: true,
+        isBattlePossible: false,
         nickname: 'Hype',
       },
       {
@@ -73,7 +73,7 @@ const DUMMY_DATA = {
           genre: '인디 / 어쿠스틱',
         },
         likeCount: 10,
-        isBattlePossible: true,
+        isBattlePossible: false,
         nickname: 'Hype',
       },
       {
@@ -97,25 +97,50 @@ const DUMMY_DATA = {
           genre: '발라드',
         },
         likeCount: 10,
-        isBattlePossible: true,
+        isBattlePossible: false,
         nickname: 'Hype',
       },
     ],
   },
 };
 
-export const getPostFeedData = async (genre: string) => {
+export const getPostFeedData = async (genre: string, possible: boolean) => {
   try {
     // const res = await axios.get('url', {
     //   headers: { 'Content-Type': 'application/json' },
     // });
 
-    if (genre === 'all') return DUMMY_DATA.data.posts;
-    else if (genre === '힙합 / 랩') return DUMMY_DATA.data.posts.slice(0, 2);
-    else if (genre === '락 / 메탈') return DUMMY_DATA.data.posts.slice(2, 4);
-    else if (genre === '인디 / 어쿠스틱') return DUMMY_DATA.data.posts.slice(4, 6);
-    else if (genre === '발라드') return DUMMY_DATA.data.posts.slice(6, 8);
-    else return [];
+    if (genre === 'all') {
+      if (possible === true) return DUMMY_DATA.data.posts.filter((_, index) => index % 2 === 0);
+      else if (possible === false) return DUMMY_DATA.data.posts.filter((_, index) => index % 2 === 1);
+      else {
+        return DUMMY_DATA.data.posts;
+      }
+    } else if (genre === '힙합 / 랩') {
+      if (possible === true) return DUMMY_DATA.data.posts.slice(0, 1);
+      else if (possible === false) return DUMMY_DATA.data.posts.slice(1, 2);
+      else {
+        return DUMMY_DATA.data.posts.slice(0, 2);
+      }
+    } else if (genre === '락 / 메탈') {
+      if (possible === true) return DUMMY_DATA.data.posts.slice(2, 3);
+      else if (possible === false) return DUMMY_DATA.data.posts.slice(3, 4);
+      else {
+        return DUMMY_DATA.data.posts.slice(2, 4);
+      }
+    } else if (genre === '인디 / 어쿠스틱') {
+      if (possible === true) return DUMMY_DATA.data.posts.slice(4, 5);
+      else if (possible === false) return DUMMY_DATA.data.posts.slice(5, 6);
+      else {
+        return DUMMY_DATA.data.posts.slice(4, 6);
+      }
+    } else if (genre === '발라드') {
+      if (possible === true) return DUMMY_DATA.data.posts.slice(6, 7);
+      else if (possible === false) return DUMMY_DATA.data.posts.slice(7, 8);
+      else {
+        return DUMMY_DATA.data.posts.slice(6, 8);
+      }
+    } else return [];
   } catch {
     throw new Error('데이터 요청 실패');
   }

--- a/src/components/post/api.ts
+++ b/src/components/post/api.ts
@@ -104,39 +104,39 @@ const DUMMY_DATA = {
   },
 };
 
-export const getPostFeedData = async (genre: string, possible: boolean) => {
+export const getPostFeedData = async (genre: string, isPossibleBattle: boolean | undefined) => {
   try {
     // const res = await axios.get('url', {
     //   headers: { 'Content-Type': 'application/json' },
     // });
 
     if (genre === 'all') {
-      if (possible === true) return DUMMY_DATA.data.posts.filter((_, index) => index % 2 === 0);
-      else if (possible === false) return DUMMY_DATA.data.posts.filter((_, index) => index % 2 === 1);
+      if (isPossibleBattle === true) return DUMMY_DATA.data.posts.filter((_, index) => index % 2 === 0);
+      else if (isPossibleBattle === false) return DUMMY_DATA.data.posts.filter((_, index) => index % 2 === 1);
       else {
         return DUMMY_DATA.data.posts;
       }
     } else if (genre === '힙합 / 랩') {
-      if (possible === true) return DUMMY_DATA.data.posts.slice(0, 1);
-      else if (possible === false) return DUMMY_DATA.data.posts.slice(1, 2);
+      if (isPossibleBattle === true) return DUMMY_DATA.data.posts.slice(0, 1);
+      else if (isPossibleBattle === false) return DUMMY_DATA.data.posts.slice(1, 2);
       else {
         return DUMMY_DATA.data.posts.slice(0, 2);
       }
     } else if (genre === '락 / 메탈') {
-      if (possible === true) return DUMMY_DATA.data.posts.slice(2, 3);
-      else if (possible === false) return DUMMY_DATA.data.posts.slice(3, 4);
+      if (isPossibleBattle === true) return DUMMY_DATA.data.posts.slice(2, 3);
+      else if (isPossibleBattle === false) return DUMMY_DATA.data.posts.slice(3, 4);
       else {
         return DUMMY_DATA.data.posts.slice(2, 4);
       }
     } else if (genre === '인디 / 어쿠스틱') {
-      if (possible === true) return DUMMY_DATA.data.posts.slice(4, 5);
-      else if (possible === false) return DUMMY_DATA.data.posts.slice(5, 6);
+      if (isPossibleBattle === true) return DUMMY_DATA.data.posts.slice(4, 5);
+      else if (isPossibleBattle === false) return DUMMY_DATA.data.posts.slice(5, 6);
       else {
         return DUMMY_DATA.data.posts.slice(4, 6);
       }
     } else if (genre === '발라드') {
-      if (possible === true) return DUMMY_DATA.data.posts.slice(6, 7);
-      else if (possible === false) return DUMMY_DATA.data.posts.slice(7, 8);
+      if (isPossibleBattle === true) return DUMMY_DATA.data.posts.slice(6, 7);
+      else if (isPossibleBattle === false) return DUMMY_DATA.data.posts.slice(7, 8);
       else {
         return DUMMY_DATA.data.posts.slice(6, 8);
       }

--- a/src/components/post/api.ts
+++ b/src/components/post/api.ts
@@ -10,7 +10,7 @@ const DUMMY_DATA = {
           musicName: 'Ditto',
           thumbnailUrl: 'url',
           singer: '뉴진스',
-          genre: 'k-pop',
+          genre: '힙합 / 랩',
         },
         likeCount: 10,
         isBattlePossible: true,
@@ -22,7 +22,7 @@ const DUMMY_DATA = {
           musicName: 'Ditto',
           thumbnailUrl: 'url',
           singer: '뉴진스',
-          genre: 'k-pop',
+          genre: '힙합 / 랩',
         },
         likeCount: 10,
         isBattlePossible: true,
@@ -34,7 +34,7 @@ const DUMMY_DATA = {
           musicName: 'Ditto',
           thumbnailUrl: 'url',
           singer: '뉴진스',
-          genre: 'k-pop',
+          genre: '락 / 메탈',
         },
         likeCount: 10,
         isBattlePossible: true,
@@ -46,7 +46,7 @@ const DUMMY_DATA = {
           musicName: 'Ditto',
           thumbnailUrl: 'url',
           singer: '뉴진스',
-          genre: 'k-pop',
+          genre: '락 / 메탈',
         },
         likeCount: 10,
         isBattlePossible: true,
@@ -58,7 +58,7 @@ const DUMMY_DATA = {
           musicName: 'Ditto',
           thumbnailUrl: 'url',
           singer: '뉴진스',
-          genre: 'k-pop',
+          genre: '인디 / 어쿠스틱',
         },
         likeCount: 10,
         isBattlePossible: true,
@@ -70,7 +70,31 @@ const DUMMY_DATA = {
           musicName: 'Ditto',
           thumbnailUrl: 'url',
           singer: '뉴진스',
-          genre: 'k-pop',
+          genre: '인디 / 어쿠스틱',
+        },
+        likeCount: 10,
+        isBattlePossible: true,
+        nickname: 'Hype',
+      },
+      {
+        postId: 7,
+        music: {
+          musicName: 'Ditto',
+          thumbnailUrl: 'url',
+          singer: '뉴진스',
+          genre: '발라드',
+        },
+        likeCount: 10,
+        isBattlePossible: true,
+        nickname: 'Hype',
+      },
+      {
+        postId: 8,
+        music: {
+          musicName: 'Ditto',
+          thumbnailUrl: 'url',
+          singer: '뉴진스',
+          genre: '발라드',
         },
         likeCount: 10,
         isBattlePossible: true,
@@ -80,13 +104,18 @@ const DUMMY_DATA = {
   },
 };
 
-export const getPostFeedData = async () => {
+export const getPostFeedData = async (genre: string) => {
   try {
     // const res = await axios.get('url', {
     //   headers: { 'Content-Type': 'application/json' },
     // });
 
-    return DUMMY_DATA.data.posts;
+    if (genre === 'all') return DUMMY_DATA.data.posts;
+    else if (genre === '힙합 / 랩') return DUMMY_DATA.data.posts.slice(0, 2);
+    else if (genre === '락 / 메탈') return DUMMY_DATA.data.posts.slice(2, 4);
+    else if (genre === '인디 / 어쿠스틱') return DUMMY_DATA.data.posts.slice(4, 6);
+    else if (genre === '발라드') return DUMMY_DATA.data.posts.slice(6, 8);
+    else return [];
   } catch {
     throw new Error('데이터 요청 실패');
   }

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -10,11 +10,11 @@ function PostList() {
   const [genre, setGenre] = useState('all');
 
   const router = useRouter();
-  const { possible } = router.query;
+  const { battle } = router.query;
 
-  const { data: postFeed, isLoading } = useQuery<PostInfo[]>(['postfeed', genre, possible], () => {
-    const possibleStatus = possible === 'true' ? true : possible === 'false' ? false : undefined;
-    return getPostFeedData(genre, possibleStatus as boolean);
+  const { data: postFeed, isLoading } = useQuery<PostInfo[]>(['postfeed', genre, battle], () => {
+    const possibleStatus = battle === 'true' ? true : battle === 'false' ? false : undefined;
+    return getPostFeedData(genre, possibleStatus);
   });
 
   const navigatePostDetail = (postId: number) => router.push(`/post/detail?postId=${postId}`);

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -2,16 +2,23 @@ import { useQuery } from '@tanstack/react-query';
 import { getPostFeedData } from './api';
 import { PostInfo } from './types';
 import { useRouter } from 'next/router';
+import Genres from '../common/Genres';
+import { useState } from 'react';
 
 function PostList() {
-  const { data: postFeed, isLoading } = useQuery<PostInfo[]>(['postfeed'], getPostFeedData);
+  const [genre, setGenre] = useState('all');
+
+  const { data: postFeed, isLoading } = useQuery<PostInfo[]>(['postfeed', genre], () => getPostFeedData(genre));
 
   const router = useRouter();
 
   const navigatePostDetail = (postId: number) => router.push(`/post/detail?postId=${postId}`);
 
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setGenre(e.target.value);
+
   return (
     <>
+      <Genres title='장르 선택' onChange={onChange} />
       {isLoading ? (
         <></>
       ) : (

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -4,13 +4,18 @@ import { PostInfo } from './types';
 import { useRouter } from 'next/router';
 import Genres from '../common/Genres';
 import { useState } from 'react';
+import Battles from '../common/Battles';
 
 function PostList() {
   const [genre, setGenre] = useState('all');
 
-  const { data: postFeed, isLoading } = useQuery<PostInfo[]>(['postfeed', genre], () => getPostFeedData(genre));
-
   const router = useRouter();
+  const { possible } = router.query;
+
+  const { data: postFeed, isLoading } = useQuery<PostInfo[]>(['postfeed', genre, possible], () => {
+    const possibleStatus = possible === 'true' ? true : possible === 'false' ? false : undefined;
+    return getPostFeedData(genre, possibleStatus as boolean);
+  });
 
   const navigatePostDetail = (postId: number) => router.push(`/post/detail?postId=${postId}`);
 
@@ -19,6 +24,7 @@ function PostList() {
   return (
     <>
       <Genres title='장르 선택' onChange={onChange} />
+      <Battles />
       {isLoading ? (
         <></>
       ) : (


### PR DESCRIPTION
## 📌 이슈 번호

- close #34 

## 👩‍💻 작업 내용

  - [x]  기존 추천 피드의 더미데이터 장르 수정하기(힙합/랩, 락/메탈, 인디/어쿠스틱, 발라드)
  - [x]  장르에 따라 render(장르 params을 통해 데이터 가져오기)
  - [x]  대결 여부에따라 render
  - [x]  컴포넌트로 정리
