### PR TITLE
feat: access token 저장 로직 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "recoil": "^0.7.6",
     "typescript": "4.9.5"
   },
   "devDependencies": {

--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -1,9 +1,11 @@
 import styled from '@emotion/styled';
 import GoogleLogo from 'public/images/google-logo.svg';
 
+import { requestLogin } from './api';
+
 export default function GoogleLoginButton() {
   return (
-    <Container>
+    <Container onClick={requestLogin}>
       <StyledGoogleLogo />
       Google로 시작하기
     </Container>

--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import GoogleLogo from 'public/images/google-logo.svg';
+
+export default function GoogleLoginButton() {
+  return (
+    <Container>
+      <StyledGoogleLogo />
+      Google로 시작하기
+    </Container>
+  );
+}
+
+const Container = styled.button`
+  position: relative;
+  background-color: #ffffff;
+  border: 0.4px solid #b7b7b7;
+  border-radius: 10px;
+  width: calc(100% - 6.8rem);
+  padding: 1.5rem 0;
+  font-family: 'Poppins';
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 22px;
+  color: #848484;
+  margin: 0 3.4rem;
+`;
+
+const StyledGoogleLogo = styled(GoogleLogo)`
+  position: absolute;
+  left: 2.2rem;
+  top: 1.7rem;
+`;

--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -1,11 +1,29 @@
 import styled from '@emotion/styled';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import GoogleLogo from 'public/images/google-logo.svg';
+import { useSetRecoilState } from 'recoil';
 
 import { requestLogin } from './api';
+import { accessTokenAtom } from './store';
 
 export default function GoogleLoginButton() {
+  const router = useRouter();
+  // 임시 코드 (API 요청 로직이 미정)
+  const { mutate: login } = useMutation({
+    mutationFn: async () => {
+      const { accessToken } = await requestLogin();
+      return accessToken;
+    },
+    onSuccess: (token) => {
+      setAccessToken(token);
+      router.push('/');
+    },
+  });
+  const setAccessToken = useSetRecoilState(accessTokenAtom);
+
   return (
-    <Container onClick={requestLogin}>
+    <Container onClick={() => login()}>
       <StyledGoogleLogo />
       Google로 시작하기
     </Container>

--- a/src/components/login/api.ts
+++ b/src/components/login/api.ts
@@ -1,0 +1,7 @@
+export const requestLogin = async () => {
+  // TODO: API 명세서 나오면 반영하기
+  await setTimeout(() => {
+    // do nothing
+  });
+  return { accessToken: 'fake token' };
+};

--- a/src/components/login/store.ts
+++ b/src/components/login/store.ts
@@ -1,0 +1,30 @@
+import { atom } from 'recoil';
+
+import { axiosInstance } from '@/api';
+import { isClientSide } from '@/utils';
+
+import { tokenStorage } from './utils/localStorage';
+
+export const accessTokenAtom = atom<string | null>({
+  key: 'accessToken',
+  default: null,
+  effects: [
+    ({ setSelf, onSet }) => {
+      if (isClientSide()) {
+        const token = tokenStorage.get();
+        if (token !== null) {
+          setSelf(token);
+        }
+      }
+
+      onSet((token, _, isReset) => {
+        if (isReset || token === null) {
+          tokenStorage.remove();
+          return;
+        }
+        tokenStorage.set(token);
+        axiosInstance.defaults.headers.common['Authorization'] = token;
+      });
+    },
+  ],
+});

--- a/src/components/login/utils/localStorage.ts
+++ b/src/components/login/utils/localStorage.ts
@@ -1,0 +1,17 @@
+import { isServerSide } from '@/utils';
+const ACCESS_TOKEN_KEY = 'serviceAccessToken';
+
+export const tokenStorage = {
+  get() {
+    if (isServerSide()) return '';
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
+  },
+  set(accessToken: string) {
+    if (isServerSide()) return;
+    localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  },
+  remove() {
+    if (isServerSide()) return;
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+  },
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { Global } from '@emotion/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
+import { RecoilRoot } from 'recoil';
 
 import { global } from '@/styles/global';
 
@@ -11,8 +12,10 @@ const queryClient = new QueryClient({
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
-      <Global styles={global} />
-      <Component {...pageProps} />
+      <RecoilRoot>
+        <Global styles={global} />
+        <Component {...pageProps} />
+      </RecoilRoot>
     </QueryClientProvider>
   );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import ImageLogo from 'public/images/image-logo.svg';
 import LetterLogo from 'public/images/letter-logo.svg';
-import GoogleLogo from 'public/images/google-logo.svg';
+
+import GoogleLoginButton from '@/components/login/GoogleLoginButton';
 
 export default function LoginPage() {
   return (
@@ -9,10 +10,7 @@ export default function LoginPage() {
       <StyledImageLogo />
       <StyledLetterLogo />
       <Slogan>What’s your Hype Music?</Slogan>
-      <GoogleLoginButton>
-        <StyledGoogleLogo />
-        Google로 시작하기
-      </GoogleLoginButton>
+      <GoogleLoginButton />
       <Footer>© 6Jeans. All rights reversed.</Footer>
     </Container>
   );
@@ -42,27 +40,6 @@ const Slogan = styled.div`
   line-height: 3rem;
   margin-top: 5.2rem;
   margin-bottom: auto;
-`;
-
-const GoogleLoginButton = styled.button`
-  position: relative;
-  background-color: #ffffff;
-  border: 0.4px solid #b7b7b7;
-  border-radius: 10px;
-  width: calc(100% - 6.8rem);
-  padding: 1.5rem 0;
-  font-family: 'Poppins';
-  font-weight: 600;
-  font-size: 15px;
-  line-height: 22px;
-  color: #848484;
-  margin: 0 3.4rem;
-`;
-
-const StyledGoogleLogo = styled(GoogleLogo)`
-  position: absolute;
-  left: 2.2rem;
-  top: 1.7rem;
 `;
 
 const Footer = styled.footer`

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+
 import reset from './reset';
 
 export const global = css`

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export const isClientSide = () => typeof window !== 'undefined';
+export const isServerSide = () => typeof window === 'undefined';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,6 +2663,11 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz"
@@ -3386,6 +3391,13 @@ react@18.2.0:
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
+
+recoil@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.6.tgz#75297ecd70bbfeeb72e861aa6141a86bb6dfcd5e"
+  integrity sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==
+  dependencies:
+    hamt_plus "1.0.2"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
## 📌 이슈 번호

- close #48

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->

아직 로그인 api가 미정이어서 access token을 받아온 이후의 로직을 먼저 구현해놓으려고 해요 (따라서 api 로직은 모두 임시 코드입니다)

그 일환으로 먼저 access token을 전역과 로컬 스토리지에 저장하는 코드를 짰습니다

시간상 문제로 일단 익숙한 방식으로 구현했고, 추후에 다음과 같은 고민들이 이루어지면 좋을 것 같아요

- localStorage에 토큰을 저장하는 것의 보안상 문제점
- 토큰을 전역에 저장하기 위해 recoil을 사용했는데 해당 라이브러리 도입이 적절한지, 더 좋은 방법이 없을지

## Reference
https://github.com/sopt-makers/sopt-playground-frontend/blob/main/components/auth/states/accessTokenAtom.ts
