### PR TITLE
feat: 구글 로그인 구현

### DIFF
--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -1,48 +1,31 @@
 import styled from '@emotion/styled';
-import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import GoogleLogo from 'public/images/google-logo.svg';
-import { useSetRecoilState } from 'recoil';
 
-import { requestLogin } from './api';
-import { accessTokenAtom } from './store';
+import { GOOGLE_LOGIN_REQUEST_URL } from './constants';
 
 export default function GoogleLoginButton() {
-  const router = useRouter();
-  // 임시 코드 (API 요청 로직이 미정)
-  const { mutate: login } = useMutation({
-    mutationFn: async () => {
-      const { accessToken } = await requestLogin();
-      return accessToken;
-    },
-    onSuccess: (token) => {
-      setAccessToken(token);
-      router.push('/');
-    },
-  });
-  const setAccessToken = useSetRecoilState(accessTokenAtom);
-
   return (
-    <Container onClick={() => login()}>
+    <StyledLink href={GOOGLE_LOGIN_REQUEST_URL} replace>
       <StyledGoogleLogo />
       Google로 시작하기
-    </Container>
+    </StyledLink>
   );
 }
 
-const Container = styled.button`
+const StyledLink = styled(Link)`
   position: relative;
   background-color: #ffffff;
   border: 0.4px solid #b7b7b7;
   border-radius: 10px;
   width: calc(100% - 6.8rem);
   padding: 1.5rem 0;
-  font-family: 'Poppins';
   font-weight: 600;
   font-size: 15px;
   line-height: 22px;
   color: #848484;
   margin: 0 3.4rem;
+  text-align: center;
 `;
 
 const StyledGoogleLogo = styled(GoogleLogo)`

--- a/src/components/login/api.ts
+++ b/src/components/login/api.ts
@@ -1,7 +1,0 @@
-export const requestLogin = async () => {
-  // TODO: API 명세서 나오면 반영하기
-  await setTimeout(() => {
-    // do nothing
-  });
-  return { accessToken: 'fake token' };
-};

--- a/src/components/login/constants.ts
+++ b/src/components/login/constants.ts
@@ -1,0 +1,5 @@
+const AUTH_API_URL = process.env.NEXT_PUBLIC_AUTH_API_URL;
+const ORIGIN = process.env.NEXT_PUBLIC_ORIGIN;
+const REDIRECT_URI = `${ORIGIN}/auth/callback/google`;
+
+export const GOOGLE_LOGIN_REQUEST_URL = `${AUTH_API_URL}/google?redirect_uri=${REDIRECT_URI}`;

--- a/src/pages/auth/callback/google.tsx
+++ b/src/pages/auth/callback/google.tsx
@@ -28,7 +28,7 @@ export default function GoogleAuthCallbackPage() {
     );
   }
 
-  return <div></div>;
+  return <></>;
 }
 
 const Container = styled.div`

--- a/src/pages/auth/callback/google.tsx
+++ b/src/pages/auth/callback/google.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useSetRecoilState } from 'recoil';
+
+import { GOOGLE_LOGIN_REQUEST_URL } from '@/components/login/constants';
+import { accessTokenAtom } from '@/components/login/store';
+import { COLOR } from '@/constants/color';
+
+export default function GoogleAuthCallbackPage() {
+  const setAccessToken = useSetRecoilState(accessTokenAtom);
+  const router = useRouter();
+  const {
+    query: { token },
+  } = router;
+
+  if (typeof token === 'string') {
+    setAccessToken(token);
+    router.push('/');
+  } else {
+    return (
+      <Container>
+        <Text>로그인에 실패했습니다</Text>
+        <StyledLink href={GOOGLE_LOGIN_REQUEST_URL} replace>
+          다시 시도
+        </StyledLink>
+      </Container>
+    );
+  }
+
+  return <div></div>;
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  gap: 2.5rem;
+`;
+
+const Text = styled.div`
+  font-size: 2rem;
+`;
+
+const StyledLink = styled(Link)`
+  background-color: ${COLOR.blue};
+  color: white;
+  border-radius: 1.6rem;
+  padding: 1rem;
+  font-size: 1.2rem;
+`;

--- a/src/pages/auth/callback/google.tsx
+++ b/src/pages/auth/callback/google.tsx
@@ -46,7 +46,7 @@ const Text = styled.div`
 
 const StyledLink = styled(Link)`
   background-color: ${COLOR.blue};
-  color: white;
+  color: ${COLOR.white};
   border-radius: 1.6rem;
   padding: 1rem;
   font-size: 1.2rem;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -33,7 +33,6 @@ const StyledLetterLogo = styled(LetterLogo)`
 
 const Slogan = styled.div`
   color: #7893ea;
-  font-family: 'Poppins';
   font-style: normal;
   font-weight: 500;
   font-size: 2rem;
@@ -43,7 +42,6 @@ const Slogan = styled.div`
 `;
 
 const Footer = styled.footer`
-  font-family: 'Poppins';
   font-style: normal;
   font-weight: 300;
   font-size: 11px;


### PR DESCRIPTION
## 📌 이슈 번호

- close #30 

## 👩‍💻 작업 내용
### 로그인 방식
`GOOGLE_LOGIN_REQUEST_URL`로 이동하면 `GoogleAuthCallbackPage`로 리다이렉트 됩니다.
리다이렉트 된 uri 쿼리 파라미터로 토큰이 담겨 있어 이를 저장한 후 홈으로 이동합니다.
<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->

### redirect 페이지 (GoogleAuthCallbackPage)
redirect 페이지는 정상적인 경우에는 아무것도 뜨지 않게 했으며, token에 문제가 있는 경우에는 아래 화면이 뜨게 해봤습니다.
(@dazzel3 디자너님 나쁘지 않죠?!)

<img width="341" alt="image" src="https://user-images.githubusercontent.com/73823388/221661253-1312d616-99bb-4981-bea5-2a6dff65af0f.png">

### 프로덕션 테스트
프로덕션 환경에서 잘 되는지 머지 후 테스트가 필요합니다.

## ➕ 추후에 하면 좋을 것들
- redirect 페이지에 로딩 애니메이션 추가
- query 파라미터로 토큰을 받는 게 보안상 위험하진 않은지 백엔드 개발자들과 논의

## 💡 궁금한 것
- `GoogleAuthCallbackPage`에 하이드레이션 오류 가능성이 있는지?
  - 서버 사이드에서는 token이 undefined라 오류 페이지가 만들어지고 클라이언트 사이드에서는 빈 페이지일텐데 왜 하이드레이션 오류가 안 나는지..?
  - useEffect를 활용해서 하이드레이션 오류를 대비해 더 방어적인 코드를 짜는 것이 좋을지?