### PR TITLE
fix: 로그인 콜백 뷰 > 토큰이 전달 됐음에도 불구하고 잠시 에러 화면이 노출되는 버그 fix

### DIFF
--- a/src/components/login/utils/localStorage.ts
+++ b/src/components/login/utils/localStorage.ts
@@ -1,5 +1,5 @@
 import { isServerSide } from '@/utils';
-const ACCESS_TOKEN_KEY = 'serviceAccessToken';
+const ACCESS_TOKEN_KEY = 'accessToken';
 
 export const tokenStorage = {
   get() {

--- a/src/pages/auth/callback/google.tsx
+++ b/src/pages/auth/callback/google.tsx
@@ -17,7 +17,7 @@ export default function GoogleAuthCallbackPage() {
   if (typeof token === 'string') {
     setAccessToken(token);
     router.push('/');
-  } else {
+  } else if (router.isReady) {
     return (
       <Container>
         <Text>로그인에 실패했습니다</Text>


### PR DESCRIPTION
## 📌 이슈 번호

- close #85

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->

useRouter query도 비동기이기 때문에 클라이언트 사이드임에도 불구하고 query.token이 undefiend인 경우가 생겨 발생한 버그였음

=> useRouter의 isReady를 통해 해결