### PR TITLE
fix: 추천 피드 목록 이벤트 버블링 막기

### DIFF
--- a/src/components/common/RecommendationPost/index.tsx
+++ b/src/components/common/RecommendationPost/index.tsx
@@ -63,6 +63,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  cursor: pointer;
 `;
 
 const Wrapper = styled.div`

--- a/src/components/common/RecommendationPost/index.tsx
+++ b/src/components/common/RecommendationPost/index.tsx
@@ -15,11 +15,15 @@ function RecommendationPost({
 }: PostInfo) {
   const router = useRouter();
 
-  const navigatePostDetail = (postId: number) => router.push(`/post/detail?postId=${postId}`);
+  const navigatePostDetail = (e: React.MouseEvent<HTMLDivElement>, postId: number) => {
+    if (e.defaultPrevented) return;
+
+    router.push(`/post/detail?postId=${postId}`);
+  };
   const navigatePostBattle = (postId: number) => router.push(`/post/battle?postId=${postId}`);
 
   return (
-    <Container key={postId} onClick={() => navigatePostDetail(postId)}>
+    <Container key={postId} onClick={(e) => navigatePostDetail(e, postId)}>
       <Wrapper>
         <AlbumPoster lazy={true} size={6} src={albumCoverUrl} />
         <Content>


### PR DESCRIPTION
## 📌 이슈 번호

- close #130 

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->
- 추천 피드에서 목록에 있는 최상위 이벤트 버블링 막기
  - 대결 신청, 좋아요 기능 정상 작동하도록
- cursor pointer 추가