### PR TITLE
fix: 대결 shorts, 상세 페이지에서 음악 재생 안되는 버그 해결

### DIFF
--- a/src/components/common/BattleMusicInfo/index.tsx
+++ b/src/components/common/BattleMusicInfo/index.tsx
@@ -15,6 +15,8 @@ const BattleMusicInfo = ({ music, onClick, clickSide }: Prop) => {
   const { albumCoverUrl, musicUrl, title, singer } = music;
 
   const handleClick = (e: any) => {
+    if (e.defaultPrevented) return;
+
     onClick?.(e);
   };
 
@@ -73,6 +75,8 @@ const Container = styled.div`
   box-shadow: 0px 0px 1.5rem rgba(158, 158, 158, 0.25);
   border-radius: 1rem;
   position: relative;
+
+  cursor: pointer;
 `;
 
 const Wrapper = styled.div`

--- a/src/components/common/Modal/Wrapper.tsx
+++ b/src/components/common/Modal/Wrapper.tsx
@@ -39,7 +39,7 @@ const Container = styled.div<{ isOpened: boolean; isAnimation: boolean }>`
   z-index: 999;
   background-color: rgba(0, 0, 0, 0.6);
 
-  & > *:first-child {
+  & > *:first-of-type {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/src/components/common/MusicPlayButton/index.tsx
+++ b/src/components/common/MusicPlayButton/index.tsx
@@ -8,7 +8,9 @@ interface Props {
 function MusicPlayButton({ src }: Props) {
   const [isMusicPlay, setIsMusicPlay] = useState(true);
 
-  const onClickPlayButton = () => {
+  const onClickPlayButton = (e: React.MouseEvent<HTMLImageElement>) => {
+    e.preventDefault();
+
     const $audioElement = document.getElementById(`audio${src}`) as HTMLAudioElement;
 
     if (isMusicPlay) $audioElement?.play();
@@ -23,7 +25,7 @@ function MusicPlayButton({ src }: Props) {
       <img
         src={`/images/${isMusicPlay ? 'play-button' : 'google-logo'}.svg`}
         alt='play button'
-        onClick={onClickPlayButton}
+        onClick={(e) => onClickPlayButton(e)}
       />
       ;
     </PlayIcon>


### PR DESCRIPTION
## 📌 이슈 번호

- close #165 

## 👩‍💻 작업 내용
- 대결 shorts, 상세 페이지에서 음악 재생 안되는 버그 해결
- gif로 변환하다보니 소리는 안 나오는데 재생 버튼 누르면 투표가 안됩니다~

![localhost_3000_battle_short-Chrome-2023-03-07-14-59-15](https://user-images.githubusercontent.com/60873508/223334645-dd3de0e1-f4fa-4495-be88-8aa0cf3b51d0.gif)


