### PR TITLE
feat: 대결 리스트 페이지 장르 필터링 구현

### DIFF
--- a/src/components/battle/list/api.ts
+++ b/src/components/battle/list/api.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { axiosInstance } from '@/api';
 
-import { Battle, GenreName } from './types';
+import { Battle, GenreValue } from './types';
 
 const battleMusicResponseScheme = z.object({ albumUrl: z.string(), singer: z.string(), title: z.string() });
 const battleResponseScheme = z.object({
@@ -14,7 +14,7 @@ const battleResponseScheme = z.object({
 });
 type BattleResponse = z.infer<typeof battleResponseScheme>;
 
-export const getBattleList = async (genre?: GenreName): Promise<Battle[]> => {
+export const getBattleList = async (genre?: GenreValue): Promise<Battle[]> => {
   const { data } = await axiosInstance.request({ method: 'GET', url: `/battles${genre ? `?genre=${genre}` : ''}` });
   return data.data.battles.map((unsafeBattle: BattleResponse) => {
     const parsed = battleResponseScheme.safeParse(unsafeBattle);

--- a/src/components/battle/list/constants.ts
+++ b/src/components/battle/list/constants.ts
@@ -1,0 +1,49 @@
+import { GenreName, GenreValue } from './types';
+
+export const GENRE_VALUE_MAP: Record<GenreName, GenreValue> = {
+  '힙합/랩': 'HIPHOP_RAP',
+  '락/메탈': 'ROCK_METAL',
+  '인디/어쿠스틱': 'INDIE_ACOUSTIC',
+  '발라드': 'BALLAD',
+  '트로트': 'TROT',
+  'K-POP': 'K_POP',
+  'R&B': 'R_AND_B',
+  '재즈': 'JAZZ',
+  'J-POP': 'J_POP',
+  '클래식': 'CLASSIC',
+  'EDM': 'EDM',
+  'POP': 'POP',
+  '기타': 'ETC',
+};
+
+export const GENRE_NAME_LIST = [
+  '힙합/랩',
+  '락/메탈',
+  '인디/어쿠스틱',
+  '발라드',
+  '트로트',
+  'K-POP',
+  'R&B',
+  '재즈',
+  'J-POP',
+  '클래식',
+  'EDM',
+  'POP',
+  '기타',
+] as const;
+
+export const GENRE_VALUE_LIST = [
+  'HIPHOP_RAP',
+  'ROCK_METAL',
+  'BALLAD',
+  'CLASSIC',
+  'EDM',
+  'ETC',
+  'INDIE_ACOUSTIC',
+  'JAZZ',
+  'J_POP',
+  'K_POP',
+  'POP',
+  'R_AND_B',
+  'TROT',
+] as const;

--- a/src/components/battle/list/hooks/useGetBattles.ts
+++ b/src/components/battle/list/hooks/useGetBattles.ts
@@ -10,5 +10,7 @@ export const useGetBattleList = (genre?: GenreValue) => {
       const data = await getBattleList(genre);
       return data;
     },
+    staleTime: 60000,
+    cacheTime: 60000,
   });
 };

--- a/src/components/battle/list/hooks/useGetBattles.ts
+++ b/src/components/battle/list/hooks/useGetBattles.ts
@@ -10,7 +10,7 @@ export const useGetBattleList = (genre?: GenreValue) => {
       const data = await getBattleList(genre);
       return data;
     },
-    staleTime: 60000,
-    cacheTime: 60000,
+    staleTime: 30000,
+    cacheTime: 30000,
   });
 };

--- a/src/components/battle/list/hooks/useGetBattles.ts
+++ b/src/components/battle/list/hooks/useGetBattles.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getBattleList } from '../api';
-import { GenreName } from '../types';
+import { GenreValue } from '../types';
 
-export const useGetBattleList = (genre?: GenreName) => {
+export const useGetBattleList = (genre?: GenreValue) => {
   return useQuery({
     queryKey: ['battleList_getBattleList', genre],
     queryFn: async () => {
-      const data = await getBattleList();
+      const data = await getBattleList(genre);
       return data;
     },
   });

--- a/src/components/battle/list/types.ts
+++ b/src/components/battle/list/types.ts
@@ -1,3 +1,5 @@
+import { GENRE_NAME_LIST, GENRE_VALUE_LIST } from './constants';
+
 export interface BattleMusic {
   albumCoverImage: string;
   title: string;
@@ -12,17 +14,10 @@ export interface Battle {
   genre: GenreName;
 }
 
-export type GenreName =
-  | '힙합/랩'
-  | '락/메탈'
-  | '인디/어쿠스틱'
-  | '발라드'
-  | '트로트'
-  | 'K-POP'
-  | 'R&B'
-  | '재즈'
-  | 'J-POP'
-  | '클래식'
-  | 'EDM'
-  | 'POP'
-  | '기타';
+export type GenreName = typeof GENRE_NAME_LIST[number];
+
+export type GenreValue = typeof GENRE_VALUE_LIST[number];
+
+export const isGenreValue = (name: string): name is GenreValue => {
+  return GENRE_VALUE_LIST.includes(name as GenreValue);
+};

--- a/src/pages/battle/list.tsx
+++ b/src/pages/battle/list.tsx
@@ -1,15 +1,34 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import ShortsIcon from 'public/images/shuffle.svg';
+import { useEffect, useState } from 'react';
 
 import BattleList from '@/components/battle/list';
 import { useGetBattleList } from '@/components/battle/list/hooks/useGetBattles';
+import { GenreValue, isGenreValue } from '@/components/battle/list/types';
 import BottomNav from '@/components/common/BottomNav';
 import Genres from '@/components/common/Genres';
 import Header from '@/components/common/Header';
 
 export default function BattleListPage() {
-  const { data: battleList } = useGetBattleList();
+  const [genreValue, setGenreValue] = useState<GenreValue | undefined>();
+  const { data: battleList, refetch: refetchBattleList } = useGetBattleList(genreValue);
+
+  const onChangeGenre = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedGenreValue = e.target.value;
+    if (selectedGenreValue === 'ALL') {
+      setGenreValue(undefined);
+      return;
+    }
+    if (!isGenreValue(selectedGenreValue)) {
+      return;
+    }
+    setGenreValue(selectedGenreValue);
+  };
+
+  useEffect(() => {
+    refetchBattleList();
+  }, [genreValue, refetchBattleList]);
 
   return (
     <>
@@ -22,7 +41,7 @@ export default function BattleListPage() {
         }
       />
       <Container>
-        <Genres shouldNeedAll />
+        <Genres shouldNeedAll onChange={onChangeGenre} />
         {battleList && <BattleList battleList={battleList} />}
       </Container>
       <BottomNav />


### PR DESCRIPTION
## 📌 이슈 번호

- close #153 

## 👩‍💻 PR Point

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->

- 추후에 Genres 컴포넌트 내부 state를 외부에서 주입하여 하나의 state만으로 필터링을 할 수 있게 리팩토링 하면 좋을 것 같습니다~

- 30초 내로 여러 번 장르 필터링을 할 때에 한 장르에 대해 refetch를 할 필요가 없다고 판단하여 staleTime과 cacheTime을 30000으로 설정했습니다