### PR TITLE
fix: 사소한 스타일 버그 fix (회원가입 및 추천 상세 페이지, 필터)

### DIFF
--- a/src/components/common/Filter.tsx
+++ b/src/components/common/Filter.tsx
@@ -33,7 +33,7 @@ const Select = styled.select`
   gap: 0.4rem;
   width: min-content;
   padding-right: 1.3rem;
-  text-align: center;
+  text-align: end;
 `;
 
 const Container = styled.div`

--- a/src/components/post/detail/index.tsx
+++ b/src/components/post/detail/index.tsx
@@ -117,7 +117,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   background: linear-gradient(130.7deg, #a274dc -10.45%, #658df4 122.15%);
   position: relative;
 `;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
 }
 
 const Container = styled.div`
-  height: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## 📌 이슈 번호

- close #206

## 👩‍💻 작업 내용


<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->

before

<img width="434" alt="image" src="https://user-images.githubusercontent.com/73823388/223700258-3ec462f6-ffe3-4fb3-bbfb-7ec2b3943bf2.png">

<img width="425" alt="image" src="https://user-images.githubusercontent.com/73823388/223700412-a87241a5-a311-44db-a27b-bd9a30341e4a.png">


after

<img width="349" alt="image" src="https://user-images.githubusercontent.com/73823388/223700185-47e102c9-4d76-4166-96d1-ab9464857eba.png">

<img width="359" alt="image" src="https://user-images.githubusercontent.com/73823388/223700467-7dc417cc-908d-43f4-b117-16d2a60a3ab5.png">

++) 추가

추천 상세 페이지에도 회원가입 페이지랑 똑같은 문제가 생겨서 수정했어요

지금 페이지 컴포넌트가 height: 100%인 곳들이 깨지네여
global.ts 커밋 내역 살펴봐도 뭐 때문인지는 모르겠네요