### PR TITLE
feat: 마이페이지 내 추천 목록 더보기 기능

### DIFF
--- a/src/components/common/NoContent/index.tsx
+++ b/src/components/common/NoContent/index.tsx
@@ -20,11 +20,7 @@ function NoContent({ text, width, isImage }: Props) {
 
 export default NoContent;
 
-interface StyleProps {
-  width: number;
-}
-
-const StyledIcon = styled(Logo)<StyleProps>`
+const StyledIcon = styled(Logo)<{ width: number }>`
   width: ${({ width }) => `${width}rem`};
 `;
 
@@ -32,5 +28,6 @@ const Text = styled.h1`
   color: ${COLOR.lightGray};
   font-size: 1.3rem;
   font-weight: 400;
+  text-align: center;
   padding: 1rem 0 2rem;
 `;

--- a/src/components/mypage/ContentList.tsx
+++ b/src/components/mypage/ContentList.tsx
@@ -20,8 +20,7 @@ function ContentList({ title, children }: Props) {
     }
 
     if (title === '추천') {
-      // 다음 이슈에서 추가 예정
-      return;
+      router.push(`mypage/post`);
     }
   };
 

--- a/src/components/mypage/api.ts
+++ b/src/components/mypage/api.ts
@@ -48,9 +48,8 @@ export const getBattlesLimit = async () => {
 
     if (data.success) {
       return data.data.battles;
-    } else {
-      return [];
     }
+    return [];
   } catch (error) {
     console.error(error);
   }

--- a/src/components/mypage/post/api.ts
+++ b/src/components/mypage/post/api.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from '@/api';
+
+import { MyPostAPI } from '../types';
+
+export const getMyPostList = async (genre?: string) => {
+  try {
+    const { data } = await axiosInstance.request<MyPostAPI>({
+      method: 'GET',
+      url: `/members/posts${genre ? `?genre=${genre}` : ''}`,
+    });
+    if (data.success) {
+      return data.data.myPosts;
+    }
+    return [];
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/components/mypage/post/useGetMyPostList.ts
+++ b/src/components/mypage/post/useGetMyPostList.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyPostList } from './api';
+
+export const useGetMyPostList = (genre?: string) => {
+  return useQuery({
+    queryKey: ['myPostList', genre],
+    queryFn: async () => {
+      const data = await getMyPostList(genre);
+      return data;
+    },
+    staleTime: 30000,
+    cacheTime: 30000,
+  });
+};

--- a/src/pages/mypage/post.tsx
+++ b/src/pages/mypage/post.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+
+import BottomNav from '@/components/common/BottomNav';
+import Genres from '@/components/common/Genres';
+import Header from '@/components/common/Header';
+import NoContent from '@/components/common/NoContent';
+import RecommendationPost from '@/components/common/RecommendationPost';
+import AuthRequiredPage from '@/components/login/AuthRequiredPage';
+import { useGetMyPostList } from '@/components/mypage/post/useGetMyPostList';
+
+export default function MyPostListPage() {
+  const [genre, setGenre] = useState<string | undefined>();
+
+  const onClickGenre = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedGenre = e.target.value;
+    if (selectedGenre === 'ALL') {
+      setGenre(undefined);
+      return;
+    }
+    setGenre(selectedGenre);
+  };
+
+  const { data: myPostList, refetch: refetchMyPostList } = useGetMyPostList(genre);
+
+  useEffect(() => {
+    refetchMyPostList();
+  }, [genre, refetchMyPostList]);
+
+  return (
+    <AuthRequiredPage>
+      <Header title='내 추천 목록' />
+      <Container>
+        <Genres shouldNeedAll onChange={onClickGenre} />
+        {myPostList ? (
+          <ListWrapper>
+            {myPostList.map(({ postId, music, likeCount, isBattlePossible }) => (
+              <RecommendationPost
+                key={postId}
+                postId={postId}
+                music={music}
+                likeCount={likeCount}
+                isBattlePossible={isBattlePossible}
+              />
+            ))}
+          </ListWrapper>
+        ) : (
+          <Wrapper>
+            <NoContent text='내 추천 목록이 없습니다.' width={8} isImage={true} />
+          </Wrapper>
+        )}
+      </Container>
+      <BottomNav />
+    </AuthRequiredPage>
+  );
+}
+
+const Container = styled.div`
+  padding: 0 2rem;
+`;
+
+const ListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;

--- a/src/pages/mypage/post.tsx
+++ b/src/pages/mypage/post.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import BottomNav from '@/components/common/BottomNav';
 import Genres from '@/components/common/Genres';
 import Header from '@/components/common/Header';
-import NoContent from '@/components/common/NoContent';
 import RecommendationPost from '@/components/common/RecommendationPost';
 import AuthRequiredPage from '@/components/login/AuthRequiredPage';
 import { useGetMyPostList } from '@/components/mypage/post/useGetMyPostList';
@@ -32,23 +31,17 @@ export default function MyPostListPage() {
       <Header title='내 추천 목록' />
       <Container>
         <Genres shouldNeedAll onChange={onClickGenre} />
-        {myPostList ? (
-          <ListWrapper>
-            {myPostList.map(({ postId, music, likeCount, isBattlePossible }) => (
-              <RecommendationPost
-                key={postId}
-                postId={postId}
-                music={music}
-                likeCount={likeCount}
-                isBattlePossible={isBattlePossible}
-              />
-            ))}
-          </ListWrapper>
-        ) : (
-          <Wrapper>
-            <NoContent text='내 추천 목록이 없습니다.' width={8} isImage={true} />
-          </Wrapper>
-        )}
+        <ListWrapper>
+          {myPostList?.map(({ postId, music, likeCount, isBattlePossible }) => (
+            <RecommendationPost
+              key={postId}
+              postId={postId}
+              music={music}
+              likeCount={likeCount}
+              isBattlePossible={isBattlePossible}
+            />
+          ))}
+        </ListWrapper>
       </Container>
       <BottomNav />
     </AuthRequiredPage>
@@ -63,15 +56,4 @@ const ListWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  align-items: center;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
 `;

--- a/src/pages/mypage/post.tsx
+++ b/src/pages/mypage/post.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import BottomNav from '@/components/common/BottomNav';
 import Genres from '@/components/common/Genres';
@@ -20,11 +20,7 @@ export default function MyPostListPage() {
     setGenre(selectedGenre);
   };
 
-  const { data: myPostList, refetch: refetchMyPostList } = useGetMyPostList(genre);
-
-  useEffect(() => {
-    refetchMyPostList();
-  }, [genre, refetchMyPostList]);
+  const { data: myPostList } = useGetMyPostList(genre);
 
   return (
     <AuthRequiredPage>


### PR DESCRIPTION
## 📌 이슈 번호

- close #179 

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->
- 마이페이지 추천 목록 더보기 `/mypage/post` 라우팅
- `/members/posts` API 연결 완료
  - 장르별 필터링 완료
- ~~처음 get 데이터 없는 경우 처리~~
  - 했다가 지웠어요. 생각해보니까 데이터가 없는 경우에는 해당 페이지로 넘어오기전에, 마이페이지 목록에서 더보기를 막거나 더보기 버튼을 없애는 처리가 선행될 예정이기 때문이죠.ㅎ

### 추후 작업
- 장르 필터링 하는 경우 데이터 없을 때 공통으로 처리하기
- 스켈레톤 전체적으로 필요한 부분 공통으로 처리하기

### ScreenShot
<img width="308" alt="스크린샷 2023-03-09 00 51 03" src="https://user-images.githubusercontent.com/50357236/223761743-75a8ebd8-3624-4098-aff4-c1b412356c47.png">

