### PR TITLE
feat: 종료된 대결 상세 페이지 구현 및 대결 상세 페이지 라우팅

### DIFF
--- a/src/components/battle/Card/Finished.tsx
+++ b/src/components/battle/Card/Finished.tsx
@@ -8,11 +8,12 @@ import { AlbumPoster, Container, Music, Singer, StyledVersus, Title } from './st
 interface FinishedCardProps {
   challenged: FinishedBattleMusic;
   challenging: FinishedBattleMusic;
+  onClick: () => void;
 }
 
-export default function FinishedBattleCard({ challenged, challenging }: FinishedCardProps) {
+export default function FinishedBattleCard({ challenged, challenging, onClick }: FinishedCardProps) {
   return (
-    <Container>
+    <Container onClick={onClick}>
       <Music>
         <StyledAlumPoster src={challenged.albumCoverImage} isWin={challenged.isWin} alt='album-cover' />
         <StyledTitle isWin={challenged.isWin}>{challenged.title}</StyledTitle>

--- a/src/components/battle/Card/index.tsx
+++ b/src/components/battle/Card/index.tsx
@@ -4,11 +4,12 @@ import { AlbumPoster, Container, Music, Singer, StyledVersus, Title } from './st
 interface BattleCardProps {
   challenged: BattleMusic;
   challenging: BattleMusic;
+  onClick: () => void;
 }
 
-export default function BattleCard({ challenged, challenging }: BattleCardProps) {
+export default function BattleCard({ challenged, challenging, onClick }: BattleCardProps) {
   return (
-    <Container>
+    <Container onClick={onClick}>
       <Music>
         <AlbumPoster src={challenged.albumCoverImage} alt='album-cover' />
         <Title>{challenged.title}</Title>

--- a/src/components/battle/detail/Battle/Finished.tsx
+++ b/src/components/battle/detail/Battle/Finished.tsx
@@ -1,5 +1,83 @@
-function Finished() {
-  return <div>Finished</div>;
+import styled from '@emotion/styled';
+
+import { Battles } from '@/components/battle/types';
+import { COLOR } from '@/constants/color';
+import useBattleMusicPlay from '@/hooks/useBattleMusicPlay';
+
+import FinishedBattleMusic from '../BattleMusic/Finished';
+
+interface FinishedBattleProps {
+  battle: Battles;
 }
 
-export default Finished;
+export default function FinishedBattle({ battle }: FinishedBattleProps) {
+  const { challenged, challenging } = battle;
+
+  const { isLeftMusicPlay, isRightMusicPlay, clickLeftButton, clickRightButton } = useBattleMusicPlay();
+
+  return (
+    <Container>
+      <Title>What’s your Hype Music?</Title>
+      <MusicContainer>
+        <FinishedBattleMusic
+          isMusicPlay={isLeftMusicPlay}
+          updatePlayStatus={clickLeftButton}
+          albumCoverImage={challenged.music.albumCoverUrl}
+          title={challenged.music.title}
+          singer={challenged.music.singer}
+          musicUrl={challenged.music.musicUrl}
+          votedCount={challenged.voteCnt ?? 0}
+          isWin={
+            typeof challenged.voteCnt === 'number' && typeof challenging.voteCnt === 'number'
+              ? challenged.voteCnt > challenging.voteCnt
+              : false
+          }
+          opponentMusicUrl={challenging.music.musicUrl}
+        />
+        <FinishedBattleMusic
+          isMusicPlay={isRightMusicPlay}
+          updatePlayStatus={clickRightButton}
+          albumCoverImage={challenging.music.albumCoverUrl}
+          title={challenging.music.title}
+          singer={challenging.music.singer}
+          musicUrl={challenging.music.musicUrl}
+          votedCount={challenging.voteCnt ?? 0}
+          isWin={
+            typeof challenging.voteCnt === 'number' && typeof challenged.voteCnt === 'number'
+              ? challenging.voteCnt > challenged.voteCnt
+              : false
+          }
+          opponentMusicUrl={challenging.music.musicUrl}
+        />
+      </MusicContainer>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 8.4rem;
+  padding-bottom: 10rem;
+  box-sizing: border-box;
+`;
+
+const Title = styled.div`
+  font-weight: 600;
+  font-size: 1.7rem;
+  line-height: 2.6rem;
+  color: ${COLOR.gray};
+  text-align: center;
+`;
+
+const MusicContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* position: relative; */
+  /* top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%); */
+  gap: 2.3rem;
+`;

--- a/src/components/battle/detail/Battle/index.tsx
+++ b/src/components/battle/detail/Battle/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
+import { Battles } from '@/components/battle/types';
 import NoContent from '@/components/common/NoContent';
 import AlbumPoster from '@/components/common/skeleton/AlbumPosterSkeleton';
 import { COLOR } from '@/constants/color';
@@ -10,18 +11,17 @@ import useBattleMusicPlay from '@/hooks/useBattleMusicPlay';
 import { SelectedBattle } from '../../types';
 import VoteResult from '../../voteResult';
 import BattleMusic from '../BattleMusic';
-import { Battles } from '../types';
 
 interface Props {
   battleId?: number | undefined;
-  musicData: Battles | undefined;
+  battle: Battles | undefined;
   isLoadingState?: boolean;
   refetch?: () => void;
   onClickSkip?: () => void;
   className?: string;
 }
 
-function Battle({ musicData, isLoadingState, refetch, onClickSkip, className }: Props) {
+function Battle({ battle, isLoadingState, refetch, onClickSkip, className }: Props) {
   const router = useRouter();
   const { id } = router.query;
   const [selectedBattle, setSelectedBattle] = useState<SelectedBattle>({
@@ -37,8 +37,8 @@ function Battle({ musicData, isLoadingState, refetch, onClickSkip, className }: 
   const { isLeftMusicPlay, isRightMusicPlay, clickLeftButton, clickRightButton } = useBattleMusicPlay();
 
   const selectBattleMusic = (clickSide: 'left' | 'right', musicId: number | undefined) => {
-    if (musicData && musicId) {
-      onChangeSelectedBattleInfo(musicData.battleId, musicId, clickSide);
+    if (battle && musicId) {
+      onChangeSelectedBattleInfo(battle.battleId, musicId, clickSide);
     }
 
     if (!id) {
@@ -51,7 +51,7 @@ function Battle({ musicData, isLoadingState, refetch, onClickSkip, className }: 
     }
   };
 
-  if (musicData == null) {
+  if (battle == null) {
     return (
       <Wrapper>
         <NoContent text='대결할 음악이 없습니다.' isImage width={8} />
@@ -74,22 +74,22 @@ function Battle({ musicData, isLoadingState, refetch, onClickSkip, className }: 
               <BattleMusic
                 isMusicPlay={isLeftMusicPlay}
                 updatePlayStatus={clickLeftButton}
-                music={musicData.challenged.music}
+                music={battle.challenged.music}
                 moving='left'
                 onClick={() => {
-                  selectBattleMusic('left', musicData.challenged.postId);
+                  selectBattleMusic('left', battle.challenged.postId);
                 }}
-                opponentMusicUrl={musicData?.challenging.music.musicUrl}
+                opponentMusicUrl={battle?.challenging.music.musicUrl}
               />
               <BattleMusic
                 isMusicPlay={isRightMusicPlay}
                 updatePlayStatus={clickRightButton}
-                music={musicData.challenging.music}
+                music={battle.challenging.music}
                 moving='right'
                 onClick={() => {
-                  selectBattleMusic('right', musicData.challenging.postId);
+                  selectBattleMusic('right', battle.challenging.postId);
                 }}
-                opponentMusicUrl={musicData?.challenged.music.musicUrl}
+                opponentMusicUrl={battle?.challenged.music.musicUrl}
               />
             </>
           )}

--- a/src/components/battle/detail/BattleMusic/Finished.tsx
+++ b/src/components/battle/detail/BattleMusic/Finished.tsx
@@ -1,5 +1,48 @@
-function Finished() {
-  return <div>Finished</div>;
+import MusicPlayButton from '@/components/common/MusicPlayButton';
+
+import { Container, PlayIcon, Singer, Thumbnail, Title, Wrapper } from './style';
+
+interface FinishedBattleMusicProps {
+  albumCoverImage: string;
+  title: string;
+  singer: string;
+  musicUrl?: string;
+  isWin: boolean;
+  votedCount: number;
+  opponentMusicUrl?: string;
+  isMusicPlay?: boolean;
+  updatePlayStatus?: () => void;
 }
 
-export default Finished;
+export default function FinishedBattleMusic({
+  albumCoverImage,
+  title,
+  singer,
+  musicUrl,
+  // TODO 스타일링 리팩토링 하고나서, 아래 안 쓰여진 prop들 이용해서 투표 상태 UI 추가해야 함
+  isWin,
+  votedCount,
+  opponentMusicUrl,
+  isMusicPlay,
+  updatePlayStatus,
+}: FinishedBattleMusicProps) {
+  return (
+    <Container>
+      <Wrapper>
+        <Thumbnail src={albumCoverImage}>
+          <PlayIcon value={musicUrl}>
+            <MusicPlayButton
+              key={title}
+              src={musicUrl}
+              opponentMusicUrl={opponentMusicUrl}
+              isMusicPlay={isMusicPlay}
+              updatePlayStatus={updatePlayStatus}
+            />
+          </PlayIcon>
+        </Thumbnail>
+        <Title>{title}</Title>
+        <Singer>{singer}</Singer>
+      </Wrapper>
+    </Container>
+  );
+}

--- a/src/components/battle/detail/BattleMusic/index.tsx
+++ b/src/components/battle/detail/BattleMusic/index.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import { MouseEvent, useRef } from 'react';
 
 import MusicPlayButton from '@/components/common/MusicPlayButton';
-import { COLOR } from '@/constants/color';
 
 import { Music } from '../types';
+import { Container, PlayIcon, Singer, Thumbnail, Title, Wrapper } from './style';
 
 interface Prop {
   music: Music;
@@ -44,7 +44,7 @@ function BattleMusic({ music, moving, onClick, opponentMusicUrl, isMusicPlay, up
   return (
     <Container>
       <Wrapper onClick={(e) => handleClick(e)} className='container'>
-        <Thumbnail src={albumCoverUrl} clickSide={moving} ref={thumbnailRef}>
+        <StyledThumbnail src={albumCoverUrl} clickSide={moving} ref={thumbnailRef}>
           <PlayIcon value={musicUrl}>
             <MusicPlayButton
               key={title}
@@ -54,7 +54,7 @@ function BattleMusic({ music, moving, onClick, opponentMusicUrl, isMusicPlay, up
               updatePlayStatus={updatePlayStatus}
             />
           </PlayIcon>
-        </Thumbnail>
+        </StyledThumbnail>
         <Title>{title}</Title>
         <Singer>{singer}</Singer>
       </Wrapper>
@@ -101,76 +101,11 @@ const changeOpacity = keyframes`
   }
 `;
 
-const Container = styled.div`
-  max-width: 20rem;
-  width: 45%;
-  height: 18rem;
-  background: ${COLOR.white};
-  box-shadow: 0px 0px 1.5rem rgba(158, 158, 158, 0.25);
-  border-radius: 1rem;
-  position: relative;
-
-  cursor: pointer;
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: absolute;
-  width: 100%;
-  top: -3rem;
-`;
-
-const Thumbnail = styled.div<{ src: string; clickSide: 'left' | 'right' | undefined }>`
-  background-image: url(${(props) => props.src});
-  background-color: ${COLOR.white};
-  background-repeat: no-repeat;
-  background-position: center center;
-  filter: drop-shadow(0 0 1.5rem rgba(158, 158, 158, 0.25));
-  border-radius: 1rem;
-  width: 10rem;
-  height: 10rem;
-  position: relative;
-  margin-bottom: 2rem;
-
+const StyledThumbnail = styled(Thumbnail)`
   &.active {
     animation: ${(props) => (props.clickSide === 'right' ? moveLeft : moveRight)} 2s ease-in;
     & > div {
       animation: ${changeOpacity} 2s ease-in;
     }
   }
-`;
-
-const PlayIcon = styled.div<{ value: string | undefined }>`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: ${(prop) => (prop.value === '' ? 'none' : 'block')};
-`;
-
-const Title = styled.div`
-  width: calc(100% - 2.5rem);
-  font-style: normal;
-  font-weight: 700;
-  font-size: 1.3rem;
-  line-height: 1.7rem;
-  text-align: center;
-  color: ${COLOR.deepBlue};
-  margin-bottom: 1rem;
-  word-break: break-all;
-  height: 3.7rem;
-  overflow-y: auto;
-`;
-
-const Singer = styled.div`
-  width: calc(100% - 1.6rem);
-  padding: 0 0.8rem;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 1.1rem;
-  line-height: 1.6rem;
-  text-align: center;
-  color: ${COLOR.gray};
 `;

--- a/src/components/battle/detail/BattleMusic/style.ts
+++ b/src/components/battle/detail/BattleMusic/style.ts
@@ -10,7 +10,6 @@ export const Container = styled.div`
   box-shadow: 0px 0px 1.5rem rgba(158, 158, 158, 0.25);
   border-radius: 1rem;
   position: relative;
-
   cursor: pointer;
 `;
 
@@ -23,7 +22,7 @@ export const Wrapper = styled.div`
   top: -3rem;
 `;
 
-export const Thumbnail = styled.div<{ src: string; clickSide: 'left' | 'right' | undefined }>`
+export const Thumbnail = styled.div<{ src: string; clickSide?: 'left' | 'right' }>`
   background-image: url(${(props) => props.src});
   background-color: ${COLOR.white};
   background-repeat: no-repeat;
@@ -33,6 +32,10 @@ export const Thumbnail = styled.div<{ src: string; clickSide: 'left' | 'right' |
   width: 10rem;
   height: 10rem;
   position: relative;
+
+  /* position: absolute;
+  left: 50%;
+  transform: translateX(-50%); */
   margin-bottom: 2rem;
 `;
 

--- a/src/components/battle/detail/BattleMusic/style.ts
+++ b/src/components/battle/detail/BattleMusic/style.ts
@@ -1,0 +1,70 @@
+import styled from '@emotion/styled';
+
+import { COLOR } from '@/constants/color';
+
+export const Container = styled.div`
+  max-width: 20rem;
+  width: 45%;
+  height: 18rem;
+  background: ${COLOR.white};
+  box-shadow: 0px 0px 1.5rem rgba(158, 158, 158, 0.25);
+  border-radius: 1rem;
+  position: relative;
+
+  cursor: pointer;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  width: 100%;
+  top: -3rem;
+`;
+
+export const Thumbnail = styled.div<{ src: string; clickSide: 'left' | 'right' | undefined }>`
+  background-image: url(${(props) => props.src});
+  background-color: ${COLOR.white};
+  background-repeat: no-repeat;
+  background-position: center center;
+  filter: drop-shadow(0 0 1.5rem rgba(158, 158, 158, 0.25));
+  border-radius: 1rem;
+  width: 10rem;
+  height: 10rem;
+  position: relative;
+  margin-bottom: 2rem;
+`;
+
+export const PlayIcon = styled.div<{ value: string | undefined }>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: ${(prop) => (prop.value === '' ? 'none' : 'block')};
+`;
+
+export const Title = styled.div`
+  width: calc(100% - 2.5rem);
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.3rem;
+  line-height: 1.7rem;
+  text-align: center;
+  color: ${COLOR.deepBlue};
+  margin-bottom: 1rem;
+  word-break: break-all;
+  height: 3.7rem;
+  overflow-y: auto;
+`;
+
+export const Singer = styled.div`
+  width: calc(100% - 1.6rem);
+  padding: 0 0.8rem;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 1.1rem;
+  line-height: 1.6rem;
+  text-align: center;
+  color: ${COLOR.gray};
+`;

--- a/src/components/battle/detail/types.ts
+++ b/src/components/battle/detail/types.ts
@@ -1,5 +1,4 @@
 export interface Battles {
-  isProgress: boolean;
   battleId: number;
   battleGenre: GenreInfo;
   challenged: BattleDetail;
@@ -9,7 +8,6 @@ export interface Battles {
 export interface BattleDetail {
   postId: number;
   music: Music;
-  voteCnt?: number;
 }
 
 export interface Music {

--- a/src/components/battle/detail/types.ts
+++ b/src/components/battle/detail/types.ts
@@ -1,4 +1,5 @@
 export interface Battles {
+  isProgress: boolean;
   battleId: number;
   battleGenre: GenreInfo;
   challenged: BattleDetail;
@@ -8,6 +9,7 @@ export interface Battles {
 export interface BattleDetail {
   postId: number;
   music: Music;
+  voteCnt?: number;
 }
 
 export interface Music {

--- a/src/components/battle/list/index.tsx
+++ b/src/components/battle/list/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
 
 import { Battle, FinishedBattleMusic } from '@/components/battle/list/types';
 
@@ -12,13 +13,20 @@ interface BattleListProps {
 }
 
 export default function BattleList({ battleList, className }: BattleListProps) {
+  const router = useRouter();
+
+  const navigateDetail = (battleId: number) => {
+    router.push(`/battle/detail?id=${battleId}`);
+  };
+
   return (
     <Container className={className}>
       {battleList?.map(({ challenged, challenging, id, battleStatus }: Battle<BattleStatusValue>) =>
         battleStatus === 'PROGRESS' ? (
-          <BattleCard challenged={challenged} challenging={challenging} key={id} />
+          <BattleCard onClick={() => navigateDetail(id)} challenged={challenged} challenging={challenging} key={id} />
         ) : (
           <FinishedBattleCard
+            onClick={() => navigateDetail(id)}
             challenged={challenged as FinishedBattleMusic}
             challenging={challenging as FinishedBattleMusic}
             key={id}

--- a/src/components/battle/types.ts
+++ b/src/components/battle/types.ts
@@ -5,11 +5,13 @@ export interface Battles {
   battleGenre: GenreInfo;
   challenged: BattleDetail;
   challenging: BattleDetail;
+  isProgress: boolean;
 }
 
 export interface BattleDetail {
   postId: number;
   music: BattleMusic;
+  voteCnt?: number;
 }
 
 export interface BattleMusic {

--- a/src/components/profile/UserContent.tsx
+++ b/src/components/profile/UserContent.tsx
@@ -25,15 +25,25 @@ function UserContent() {
     async () => await getPostFeedLimit(Number(memberId)),
   );
 
+  const navigateDetail = (battleId: number) => {
+    router.push(`/battle/detail?id=${battleId}`);
+  };
+
   return (
     <Container>
       <ContentList title='대결' hasList={battleLimit?.length !== 0}>
         {battleLimit?.length ? (
           battleLimit.map(({ id, challenging, challenged, battleStatus }) =>
             battleStatus === 'PROGRESS' ? (
-              <BattleCard key={id} challenging={challenging} challenged={challenged} />
+              <BattleCard
+                onClick={() => navigateDetail(id)}
+                key={id}
+                challenging={challenging}
+                challenged={challenged}
+              />
             ) : (
               <FinishedBattleCard
+                onClick={() => navigateDetail(id)}
                 key={id}
                 challenging={challenging as FinishedBattleMusic}
                 challenged={challenged as FinishedBattleMusic}

--- a/src/pages/battle/detail.tsx
+++ b/src/pages/battle/detail.tsx
@@ -12,7 +12,7 @@ import AuthRequiredPage from '@/components/login/AuthRequiredPage';
 function Detail() {
   const router = useRouter();
   const { id } = router.query;
-  const { data: musicData } = useGetBattle({ initBattleId: Number(id), selectedGenre: 'ALL' });
+  const { data: battle } = useGetBattle({ initBattleId: Number(id), selectedGenre: 'ALL' });
 
   return id ? (
     <AuthRequiredPage>
@@ -25,7 +25,7 @@ function Detail() {
         }
       />
       <Container>
-        <Battle musicData={musicData} />
+        <Battle battle={battle} />
       </Container>
       <BottomNav />
     </AuthRequiredPage>

--- a/src/pages/battle/detail.tsx
+++ b/src/pages/battle/detail.tsx
@@ -32,7 +32,9 @@ function Detail() {
           </Link>
         }
       />
-      <Container>{battle && (battle.isProgress ? <Battle battle={battle} /> : <FinishedBattle />)}</Container>
+      <Container>
+        {battle && (battle.isProgress ? <Battle battle={battle} /> : <FinishedBattle battle={battle} />)}
+      </Container>
       <BottomNav />
     </AuthRequiredPage>
   ) : (
@@ -48,4 +50,7 @@ const Container = styled.div`
   min-height: 60rem;
   padding: 0 2rem;
   padding-top: 1.27rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;

--- a/src/pages/battle/detail.tsx
+++ b/src/pages/battle/detail.tsx
@@ -14,10 +14,17 @@ function Detail() {
   const { id } = router.query;
   const { data: battle } = useGetBattle({ initBattleId: Number(id), selectedGenre: 'ALL' });
 
+  const getHeaderTitle = () => {
+    if (!battle) {
+      return '';
+    }
+    return battle.isProgress ? '진행 중인 대결' : '종료된 대결';
+  };
+
   return id ? (
     <AuthRequiredPage>
       <Header
-        title='진행 중인 대결'
+        title={getHeaderTitle()}
         actionButton={
           <Link href='/battle/list'>
             <ListIcon />

--- a/src/pages/battle/detail.tsx
+++ b/src/pages/battle/detail.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import ListIcon from 'public/images/go-to-list-icon.svg';
 
+import FinishedBattle from '@/components/battle/detail/Battle/Finished';
 import Battle from '@/components/battle/detail/Battle/index';
 import { useGetBattle } from '@/components/battle/detail/useGetBattle';
 import BottomNav from '@/components/common/BottomNav';
@@ -31,9 +32,7 @@ function Detail() {
           </Link>
         }
       />
-      <Container>
-        <Battle battle={battle} />
-      </Container>
+      <Container>{battle && (battle.isProgress ? <Battle battle={battle} /> : <FinishedBattle />)}</Container>
       <BottomNav />
     </AuthRequiredPage>
   ) : (

--- a/src/pages/battle/short.tsx
+++ b/src/pages/battle/short.tsx
@@ -43,7 +43,7 @@ function Short() {
       />
       <Container>
         <Genres onChange={onClickGenre} shouldNeedAll />
-        <Battle musicData={musicData} isLoadingState={isLoadingState} refetch={refetch} onClickSkip={onClickSkip} />
+        <Battle battle={musicData} isLoadingState={isLoadingState} refetch={refetch} onClickSkip={onClickSkip} />
       </Container>
       <BottomNav />
     </>


### PR DESCRIPTION
## 📌 이슈 번호

- close #144

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->

해당 기능 구현하다가 BattleMusic과 Battle에 외부에서 영향을 받는 스타일 요소가 너무 많아서 도무지 스타일링을 이어나갈 수가 없어서 가능한 기능까지만 완성해서 올립니다

못한 것
- 스타일링 완성
- FinishedBattleMusic에 투표수 컴포넌트 추가

위 사항들은 새 이슈 파서 스타일링 뜯어 고친 후에 해보겠습니다
계속 붙잡고 해봤는데 안 뜯어고치고선 완성을 못할 것 같아요 ..