### PR TITLE
chore: 메인 페이지 스타일 수정

### DIFF
--- a/src/components/common/AlbumPoster/index.tsx
+++ b/src/components/common/AlbumPoster/index.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import { useEffect, useRef, useState } from 'react';
 
+import { COLOR } from '@/constants/color';
+
 let observer = null;
 const LOAD_IMG_EVENT_TYPE = 'loadImage';
 
@@ -69,8 +71,8 @@ const ImgContainer = styled.div`
   width: ${({ size }: StyleProps) => `${size}rem`};
   height: ${({ size }: StyleProps) => `${size}rem`};
   border-radius: 1rem;
-  background: #fff;
-  filter: drop-shadow(0px 0px 15px rgba(158, 158, 158, 0.25));
+  background: ${COLOR.white};
+  box-shadow: 0px 0px 10px rgba(158, 158, 158, 0.25);
 
   & > div {
     position: absolute;

--- a/src/components/main/GenreTop10Post/DeskTopPosts.tsx
+++ b/src/components/main/GenreTop10Post/DeskTopPosts.tsx
@@ -14,10 +14,10 @@ interface Props {
 function DeskTopPosts({ genreTop10Post, navigatePostDetail }: Props) {
   return (
     <Container>
-      <Swiper spaceBetween={50} slidesPerView={6}>
+      <Swiper spaceBetween={20} slidesPerView={6}>
         {genreTop10Post?.map(({ postId, music: { albumCoverUrl, title, singer } }) => (
           <SwiperSlide key={postId} onClick={() => navigatePostDetail(postId)}>
-            <AlbumPoster lazy={true} size={12.5} src={albumCoverUrl} />
+            <AlbumPoster lazy={true} size={10} src={albumCoverUrl} />
             <TitleSinger>
               <div>{title}</div>
               <div>{singer}</div>
@@ -33,6 +33,7 @@ export default DeskTopPosts;
 
 const Container = styled.div`
   overflow: hidden;
+  cursor: pointer;
 
   & .swiper-wrapper {
     display: -webkit-inline-box;
@@ -40,21 +41,31 @@ const Container = styled.div`
 `;
 
 const TitleSinger = styled.div`
-  margin: 1rem 0 0 0.5rem;
+  margin-top: 1rem;
+  width: 100%;
+  word-break: break-all;
 
   & div:first-of-type {
-    font-weight: 500;
-    font-size: 1rem;
-    line-height: 1.8rem;
-
+    font-weight: 600;
+    font-size: 1.1rem;
+    line-height: 1.4rem;
     color: ${COLOR.deepBlue};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
-
   & div:last-of-type {
     font-weight: 500;
-    font-size: 0.9rem;
+    font-size: 1rem;
     line-height: 1.4rem;
-
     color: ${COLOR.gray};
+    margin-top: 0.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 `;

--- a/src/components/main/GenreTop10Post/MobilePosts.tsx
+++ b/src/components/main/GenreTop10Post/MobilePosts.tsx
@@ -15,7 +15,7 @@ function MobilePosts({ genreTop10Post, navigatePostDetail }: Props) {
     <Posts>
       {genreTop10Post?.map(({ postId, music: { albumCoverUrl, title, singer } }) => (
         <Post key={postId} onClick={() => navigatePostDetail(postId)}>
-          <AlbumPoster lazy={true} size={12.5} src={albumCoverUrl} />
+          <AlbumPoster lazy={true} size={10} src={albumCoverUrl} />
           <TitleSinger>
             <div>{title}</div>
             <div>{singer}</div>
@@ -30,9 +30,10 @@ export default MobilePosts;
 
 const Posts = styled.div`
   display: flex;
-  margin-top: -0.5rem;
-
   overflow-x: scroll;
+  gap: 2rem;
+  cursor: pointer;
+
   &::-webkit-scrollbar {
     display: none;
   }
@@ -41,22 +42,34 @@ const Posts = styled.div`
 const Post = styled.div`
   display: flex;
   flex-direction: column;
-  margin-right: 0.5rem;
-  width: 12.5rem;
 `;
 
 const TitleSinger = styled.div`
-  margin: 1rem 0 0 0.5rem;
+  margin-top: 1rem;
+  width: 100%;
+  word-break: break-all;
+
   & div:first-of-type {
-    font-weight: 500;
-    font-size: 1rem;
-    line-height: 1.8rem;
+    font-weight: 600;
+    font-size: 1.1rem;
+    line-height: 1.4rem;
     color: ${COLOR.deepBlue};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
   & div:last-of-type {
     font-weight: 500;
-    font-size: 0.9rem;
+    font-size: 1rem;
     line-height: 1.4rem;
     color: ${COLOR.gray};
+    margin-top: 0.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 `;

--- a/src/components/ranking/index.tsx
+++ b/src/components/ranking/index.tsx
@@ -59,7 +59,7 @@ const RankingContainer = styled.div`
   gap: 0.8rem;
   padding: 0 2rem;
   height: calc(100% - 10rem);
-  overflow-y: scroll;
+  overflow-y: auto;
 
   &.full {
     position: relative;

--- a/src/components/ranking/index.tsx
+++ b/src/components/ranking/index.tsx
@@ -58,8 +58,6 @@ const RankingContainer = styled.div`
   flex-direction: column;
   gap: 0.8rem;
   padding: 0 2rem;
-  height: calc(100% - 10rem);
-  overflow-y: auto;
 
   &.full {
     position: relative;

--- a/src/pages/battle/short.tsx
+++ b/src/pages/battle/short.tsx
@@ -31,7 +31,7 @@ function Short() {
   };
 
   return (
-    <>
+    <Container>
       <Header
         title='진행 중인 대결'
         shouldNeedBack={false}
@@ -41,18 +41,22 @@ function Short() {
           </Link>
         }
       />
-      <Container>
+      <Wrapper>
         <Genres onChange={onClickGenre} shouldNeedAll />
         <Battle musicData={musicData} isLoadingState={isLoadingState} refetch={refetch} onClickSkip={onClickSkip} />
-      </Container>
+      </Wrapper>
       <BottomNav />
-    </>
+    </Container>
   );
 }
 
 export default Short;
 
 const Container = styled.div`
+  height: 100vh;
+`;
+
+const Wrapper = styled.div`
   width: calc(100% - 4rem);
   height: calc(100vh - 22rem);
   padding: 0 2rem;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,7 +87,7 @@ const StyledLogo = styled(Logo)`
 `;
 
 const Wrapper = styled.div`
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.4rem;
 `;
 
 const Label = styled.span`
@@ -108,6 +108,7 @@ const LikeGenrePost = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: 3rem;
+  gap: 0.2rem;
 `;
 
 const SeeMore = styled.span`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,9 @@ export default function Home() {
         <StyledRandomBattle battle={randomBattle} onClick={() => onClickRandomBattle(randomBattle.battleId)} />
       )}
       <LikeGenrePost>
-        <Label>이런 곡은 어때요?</Label>
+        <Wrapper>
+          <Label>이런 곡은 어때요?</Label>
+        </Wrapper>
         <Genres onChange={onChange} shouldNeedAll />
         {mobile
           ? genreTop10Post && <MobilePosts genreTop10Post={genreTop10Post} navigatePostDetail={navigatePostDetail} />
@@ -69,60 +71,67 @@ export default function Home() {
 }
 
 const Container = styled.div`
-  width: calc(100% - 4rem);
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   padding: 0 2rem;
   width: 100%;
   box-sizing: border-box;
 `;
 
 const StyledLogo = styled(Logo)`
-  width: 5.5rem;
-  height: 1.2rem;
-  margin-top: 2.5rem;
-  margin-bottom: 1.8rem;
+  width: 6.6rem;
+  padding: 2.5rem 0;
   position: relative;
   left: 50%;
   transform: translateX(-50%);
 `;
 
+const Wrapper = styled.div`
+  margin-bottom: 1.5rem;
+`;
+
 const Label = styled.span`
   font-weight: 700;
   font-size: 1.6rem;
-  line-height: 2.3rem;
-  margin-bottom: 1.7rem;
 `;
 
 const RankingLabels = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
 `;
 
 const LikeGenrePost = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  padding-bottom: 9.5rem;
+  margin-bottom: 3rem;
 `;
 
 const SeeMore = styled.span`
+  color: ${COLOR.gray};
+  font-weight: 500;
   font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
 `;
 
 const StyledArrowRight = styled(ArrowRight)`
   & > path {
-    stroke: ${COLOR.deepBlue};
+    stroke: ${COLOR.gray};
   }
 `;
 
 const StyledRandomBattle = styled(RandomBattle)`
-  margin-bottom: 2.9rem;
+  margin-top: 2rem;
+  margin-bottom: 4rem;
   cursor: pointer;
+
   &:hover {
     transform: scale(1.01);
-    transition: all 0.1s ease;
+    transition: 0.2s ease-in-out;
   }
 `;

--- a/src/pages/post/battle/index.tsx
+++ b/src/pages/post/battle/index.tsx
@@ -1,12 +1,20 @@
+import styled from '@emotion/styled';
+
 import AuthRequiredPage from '@/components/login/AuthRequiredPage';
 import BattleForm from '@/components/post/battle';
 
 function Battle() {
   return (
     <AuthRequiredPage>
-      <BattleForm />
+      <Container>
+        <BattleForm />
+      </Container>
     </AuthRequiredPage>
   );
 }
 
 export default Battle;
+
+const Container = styled.div`
+  height: 100vh;
+`;

--- a/src/pages/post/searchMusics.tsx
+++ b/src/pages/post/searchMusics.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import Header from '@/components/common/Header';
 import AuthRequiredPage from '@/components/login/AuthRequiredPage';
 import PostSearchMusics from '@/components/post/SearchMusics/index';
@@ -8,16 +10,22 @@ function SearchMusics() {
 
   return (
     <AuthRequiredPage>
-      <Header title='추천 글쓰기' backUrl='/' />
-      <PostSearchMusics
-        keyword={keyword}
-        tmpKeyword={tmpKeyword}
-        onChangeKeyword={onChangeKeyword}
-        onClickInSearchButton={onClickInSearchButton}
-        onClickInMusicList={onClickInMusicList}
-      />
+      <Container>
+        <Header title='추천 글쓰기' backUrl='/' />
+        <PostSearchMusics
+          keyword={keyword}
+          tmpKeyword={tmpKeyword}
+          onChangeKeyword={onChangeKeyword}
+          onClickInSearchButton={onClickInSearchButton}
+          onClickInMusicList={onClickInMusicList}
+        />
+      </Container>
     </AuthRequiredPage>
   );
 }
 
 export default SearchMusics;
+
+const Container = styled.div`
+  height: 100vh;
+`;

--- a/src/pages/profile/post.tsx
+++ b/src/pages/profile/post.tsx
@@ -28,31 +28,37 @@ export default function MyPostListPage() {
 
   return (
     <AuthRequiredPage>
-      <Header title={memberId ? '추천 목록' : '내 추천 목록'} />
       <Container>
-        <Genres shouldNeedAll onChange={onClickGenre} />
-        <ListWrapper>
-          {myPostList?.length ? (
-            myPostList.map(({ postId, music, likeCount, isBattlePossible }) => (
-              <RecommendationPost
-                key={postId}
-                postId={postId}
-                music={music}
-                likeCount={likeCount}
-                isBattlePossible={isBattlePossible}
-              />
-            ))
-          ) : (
-            <Wrapper>
-              <NoContent text='추천한 음악이 없습니다.' isImage width={8} />
-            </Wrapper>
-          )}
-        </ListWrapper>
+        <Header title={memberId ? '추천 목록' : '내 추천 목록'} />
+        <Content>
+          <Genres shouldNeedAll onChange={onClickGenre} />
+          <ListWrapper>
+            {myPostList?.length ? (
+              myPostList.map(({ postId, music, likeCount, isBattlePossible }) => (
+                <RecommendationPost
+                  key={postId}
+                  postId={postId}
+                  music={music}
+                  likeCount={likeCount}
+                  isBattlePossible={isBattlePossible}
+                />
+              ))
+            ) : (
+              <Wrapper>
+                <NoContent text='추천한 음악이 없습니다.' isImage width={8} />
+              </Wrapper>
+            )}
+          </ListWrapper>
+        </Content>
+        <BottomNav />
       </Container>
-      <BottomNav />
     </AuthRequiredPage>
   );
 }
+
+const Container = styled.div`
+  height: 100vh;
+`;
 
 const Wrapper = styled.div`
   display: flex;
@@ -65,7 +71,7 @@ const Wrapper = styled.div`
   gap: 0.5rem;
 `;
 
-const Container = styled.div`
+const Content = styled.div`
   padding: 0 2rem;
 `;
 

--- a/src/pages/ranking/index.tsx
+++ b/src/pages/ranking/index.tsx
@@ -1,13 +1,28 @@
+import styled from '@emotion/styled';
+
 import Header from '@/components/common/Header';
 import Ranking from '@/components/ranking';
 
 function RankingPage() {
   return (
-    <>
+    <Container>
       <Header title='유저랭킹' backUrl='/' />
-      <Ranking isLimit={false} />
-    </>
+      <Wrapper>
+        <Ranking isLimit={false} />
+      </Wrapper>
+    </Container>
   );
 }
 
 export default RankingPage;
+
+const Container = styled.div`
+  overflow: hidden;
+  height: 100vh;
+`;
+
+const Wrapper = styled.div`
+  height: calc(100vh - 12rem);
+  overflow-y: scroll;
+  padding-bottom: 3rem;
+`;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -16,13 +16,11 @@ export const global = css`
     max-width: 768px;
     min-width: 350px;
     margin: 0 auto;
-    height: 100%;
   }
 
   #__next,
   #root {
     width: 100%;
-    height: 100%;
     background-color: ${COLOR.background};
     color: ${COLOR.deepBlue};
   }

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -3,6 +3,11 @@ import { css } from '@emotion/react';
 import { COLOR } from '@/constants/color';
 
 const reset = css`
+  * {
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
   html,
   body,
   div,


### PR DESCRIPTION
## 📌 이슈 번호

- close #290 

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->
- [x] 이런 곡은 어때요? → 앨범 디자인 수정
    - [x] 100 x 100 앨범 커버에 흰색 없애기
- [x]  이런 곡은 어때요? 에서 제목이 길어지면 2줄
    - [x]  타이틀 영역 수정
    - [x]  오늘의 TOP 5가 움직임과 사이간격 수정
- [x] 전체 페이지 height 백그라운드 짤림 수정
- [x] 전역 스크롤바 없애기 

### ScreenShot
- before
<img width="305" alt="스크린샷 2023-03-12 17 51 19" src="https://user-images.githubusercontent.com/50357236/224534345-20c1bb74-a495-4986-a820-bac09f308f42.png">

- after
<img width="306" alt="스크린샷 2023-03-12 17 51 53" src="https://user-images.githubusercontent.com/50357236/224534375-fb7c66a9-26e1-4c75-8e26-0214d06c5bf9.png">

