### PR TITLE
fix: 대결 관련 페이지 스타일 문제 수정

### DIFF
--- a/src/pages/battle/list.tsx
+++ b/src/pages/battle/list.tsx
@@ -83,7 +83,7 @@ const StyledGenres = styled(Genres)`
 const StyledBattleList = styled(BattleList)`
   height: calc(100vh - 25rem);
   overflow-y: auto;
-  margin-top: 1.3rem;
+  margin-top: 1.5rem;
 `;
 
 const Wrapper = styled.div`

--- a/src/pages/battle/list.tsx
+++ b/src/pages/battle/list.tsx
@@ -12,6 +12,7 @@ import BottomNav from '@/components/common/BottomNav';
 import Filter from '@/components/common/Filter';
 import Genres from '@/components/common/Genres';
 import Header from '@/components/common/Header';
+import NoContent from '@/components/common/NoContent';
 
 export default function BattleListPage() {
   const [genreValue, setGenreValue] = useState<GenreValue | undefined>();
@@ -38,7 +39,7 @@ export default function BattleListPage() {
   };
 
   return (
-    <>
+    <Container>
       <Header
         title='한 눈에 보는 대결'
         shouldNeedBack={false}
@@ -48,17 +49,27 @@ export default function BattleListPage() {
           </Link>
         }
       />
-      <Container>
+      <Content>
         <StyledGenres shouldNeedAll onChange={onChangeGenre} />
         <Filter selected={status} options={BATTLE_STATUS_NAME_LIST} onChange={onChangeFilter} />
-        {battleList && <StyledBattleList battleList={battleList} />}
-      </Container>
+        {battleList?.length ? (
+          <StyledBattleList battleList={battleList} />
+        ) : (
+          <Wrapper>
+            <NoContent text='생성된 대결이 없습니다.' isImage width={8} />
+          </Wrapper>
+        )}
+      </Content>
       <BottomNav />
-    </>
+    </Container>
   );
 }
 
 const Container = styled.div`
+  height: 100vh;
+`;
+
+const Content = styled.div`
   padding: 0 2rem;
   display: flex;
   flex-direction: column;
@@ -70,5 +81,18 @@ const StyledGenres = styled(Genres)`
 `;
 
 const StyledBattleList = styled(BattleList)`
+  height: calc(100vh - 25rem);
+  overflow-y: auto;
   margin-top: 1.3rem;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  gap: 1.5rem;
 `;

--- a/src/pages/profile/battle/index.tsx
+++ b/src/pages/profile/battle/index.tsx
@@ -45,7 +45,7 @@ export default function MyBattleListPage() {
             <StyledBattleList battleList={myBattleList} />
           ) : (
             <Wrapper>
-              <NoContent text='생성된 대결이 없습니다.' isImage width={8} />
+              <NoContent text='참여한 대결이 없습니다.' isImage width={8} />
             </Wrapper>
           )}
         </Content>

--- a/src/pages/profile/battle/index.tsx
+++ b/src/pages/profile/battle/index.tsx
@@ -9,6 +9,7 @@ import BottomNav from '@/components/common/BottomNav';
 import Filter from '@/components/common/Filter';
 import Genres from '@/components/common/Genres';
 import Header from '@/components/common/Header';
+import NoContent from '@/components/common/NoContent';
 import AuthRequiredPage from '@/components/login/AuthRequiredPage';
 import { useGetMyBattleList } from '@/components/profile/battle/useGetMyBattleList';
 
@@ -35,18 +36,30 @@ export default function MyBattleListPage() {
 
   return (
     <AuthRequiredPage>
-      <Header title='참여한 대결' />
       <Container>
-        <Genres shouldNeedAll onChange={onChangeGenre} />
-        <Filter selected={status} options={BATTLE_STATUS_NAME_LIST} onChange={onChangeFilter} />
-        {myBattleList && <StyledBattleList battleList={myBattleList} />}
+        <Header title='참여한 대결' />
+        <Content>
+          <Genres shouldNeedAll onChange={onChangeGenre} />
+          <Filter selected={status} options={BATTLE_STATUS_NAME_LIST} onChange={onChangeFilter} />
+          {myBattleList?.length ? (
+            <StyledBattleList battleList={myBattleList} />
+          ) : (
+            <Wrapper>
+              <NoContent text='생성된 대결이 없습니다.' isImage width={8} />
+            </Wrapper>
+          )}
+        </Content>
+        <BottomNav />
       </Container>
-      <BottomNav />
     </AuthRequiredPage>
   );
 }
 
 const Container = styled.div`
+  height: 100vh;
+`;
+
+const Content = styled.div`
   padding: 0 2rem;
   display: flex;
   flex-direction: column;
@@ -54,5 +67,18 @@ const Container = styled.div`
 `;
 
 const StyledBattleList = styled(BattleList)`
-  margin-top: 1.3rem;
+  height: calc(100vh - 25rem);
+  overflow-y: auto;
+  margin-top: 1.5rem;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  gap: 1.5rem;
 `;


### PR DESCRIPTION
## 📌 이슈 번호

- close #342

## 👩‍💻 작업 내용

<!-- (자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok) -->
- NoContent 적용
- height 적용
- Content 영역 overflow-y: auto; 적용

### ScreenShot
- before
<img width="304" src="https://user-images.githubusercontent.com/50357236/224583011-6b91fe45-1a06-41d9-b67e-e4f338c402ef.png">
<img width="304"  src="https://user-images.githubusercontent.com/50357236/224583024-526486f9-abd9-477b-8b20-e24903850fc4.png">

- after
<img width="304" alt="스크린샷 2023-03-13 08 53 27" src="https://user-images.githubusercontent.com/50357236/224581745-3ed2f5ab-9a03-4846-bd6b-7f70c2267f47.png">
<img width="310" alt="스크린샷 2023-03-13 08 53 44" src="https://user-images.githubusercontent.com/50357236/224581757-3707bb1f-a407-48b6-8879-1bc23c9ce147.png">
