### PR TITLE
fix: 투표 결과 모달 '돌아가기' 버튼 라우팅 404 에러 고치기

### DIFF
--- a/src/components/battle/voteResult/index.tsx
+++ b/src/components/battle/voteResult/index.tsx
@@ -35,7 +35,7 @@ function VoteResult({ battleId, votedPostId, clickSide }: Props) {
             <StyledIcon />
             {clickSide === 'right' ? selected : opposite}
           </Votes>
-          {isDetail && <Back onClick={() => router.push('/list')}>돌아가기</Back>}
+          {isDetail && <Back onClick={() => router.push('/battle/list')}>돌아가기</Back>}
         </VoteResultContainer>
       </Wrapper>
     </VoteResultModal>


### PR DESCRIPTION
## 📌 이슈 번호

- close #326 

## 👩‍💻 작업 내용
투표 결과 모달 '돌아가기' 버튼 라우팅 404 에러 고치기
