### PR TITLE
fix: 진행종료된 대결 음악 플레이 문제 해결

### DIFF
--- a/src/components/battle/detail/Battle/Finished.tsx
+++ b/src/components/battle/detail/Battle/Finished.tsx
@@ -49,7 +49,7 @@ export default function FinishedBattle({ battle, useBattleMusicPlayFunctions, cl
               ? challenging.voteCnt > challenged.voteCnt
               : false
           }
-          opponentMusicUrl={challenging.music.musicUrl}
+          opponentMusicUrl={challenged.music.musicUrl}
         />
       </BattleMusicWrapper>
     </Container>


### PR DESCRIPTION
## 📌 이슈 번호

- close #334 

## 👩‍💻 작업 내용

- [ ] 왼쪽에서 플레이 중일 때 오른쪽 플레이 버튼 누르면 왼쪽에 pause가 안되는 문제 해결
